### PR TITLE
Describe how to add separate cache file path

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -111,8 +111,13 @@ Pulling a new version can take several minutes, depending on your internet conne
 
 ## Various questions ##
 
+### Other container versions ###
+
 Currently, we have no experience with using [Podman](https://podman.io/) instead
 of Docker. Please let us know if you do!
+
+There is currently no LXC container build for Photoprism, see [this
+issue](https://github.com/photoprism/photoprism/issues/147) for more detail.
 
 ## Troubleshooting ##
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -111,13 +111,73 @@ Pulling a new version can take several minutes, depending on your internet conne
 
 ## Various questions ##
 
+Further setup questions that have come up so far, in no systematic order.
+
+
 ### Other container versions ###
 
 Currently, we have no experience with using [Podman](https://podman.io/) instead
 of Docker. Please let us know if you do!
 
-There is currently no LXC container build for Photoprism, see [this
-issue](https://github.com/photoprism/photoprism/issues/147) for more detail.
+There is currently no [LXC container](https://linuxcontainers.org/) build for
+PhotoPrism, see [this
+discussion](https://github.com/photoprism/photoprism/issues/147) for more detail.
+
+
+### Placing the cache on a fast filesystem ### 
+
+Some users might want to place the thumbnail cache on a separate, faster file
+system while keeping the actual photo files on large, slow bulk storage. This
+should result in faster access to the thumbnails. 
+
+To do this, we add a further volume (`-v`) parameter to the docker script so we
+use an _external_ path (outside the container) for the cache files. You can get
+the _internal_ path with `photoprism config`, or as a docker command in a
+running system (for Linux/BSD systems): 
+
+```
+sudo docker exec photoprism photoprism config | grep cache-path
+```
+
+This should return a line such as:
+
+```
+cache-path            /home/photoprism/.cache/photoprism
+```
+
+for the internal path. We now know to add a line like
+
+```
+  -v <MYCACHE_FOLDER>:/home/photoprism/.cache/photoprism \
+```
+
+to the docker invocation, with your actual path to the cache folder replacing
+`<MYCACHE_FOLDER>`. 
+
+As an example, let's assume a [ZFS
+filesystem](https://en.wikipedia.org/wiki/ZFS) with two pools ("volumes" in
+classical terminology): A pool _tank_ in a raidz2 (RAID6) configuration based on
+hard drives that holds the original pictures, and a pool _dozer_ in a mirrored
+(RAID1) configuration based on SSD or NVMe drives to store the thumbnails. Our
+docker script could be:
+
+```
+docker run -d \
+  --name photoprism \
+  -p 2342:2342 \
+  -v /tank/photos/:/home/photoprism/Pictures/Originals \
+  -v /dozer/cache/:/home/photoprism/.cache/photoprism \
+  photoprism/photoprism
+```
+
+In a case like this, you will probably also want to optimize the datasets ("file
+systems") `tank/photos` and `dozer/cache` further. For instance, the
+original photo files will call for a larger recordsize than the smaller cache
+files. 
+
+A discussion about optimizing file systems for PhotoPrism is currently
+outside of the scope of this document. 
+
 
 ## Troubleshooting ##
 


### PR DESCRIPTION
Closes #5 by adding a description with examples of how to find the cache folder inside the container and exposing to the outside via a second `--volume` parameter of a docker script. Includes on example based on test setup with a ZFS file system Ubuntu 18.04 LTS and two pools. See discussion at https://github.com/photoprism/photoprism/issues/178 . 

Separately, point out that there are currently no LXC builds for PhotoPrism.