### PR TITLE
Fix Broken MkDocs List Format

### DIFF
--- a/docs/developer-guide/tests.md
+++ b/docs/developer-guide/tests.md
@@ -6,6 +6,7 @@
 To run all unit tests, type `make test` or `go test ./internal/...` in a terminal.
 
 These `make` targets are currently defined for tests:
+
 - `test`: Executes all tests found in a) */internal* with a timeout of 20 min and verbose output and b) *frontend/tests/unit*
 - `test-short`: Executes only fast tests found in */internal* with a timeout of 5 min and verbose output
 - `test-race`: Same as `test` but with race condition detector (much slower) and higher timeout of 60 min

--- a/docs/getting-started/kubernetes.md
+++ b/docs/getting-started/kubernetes.md
@@ -13,6 +13,7 @@ For those familiar with [Helm](https://helm.sh), a PhotoPrism Helm chart [is ava
 Once you've got PhotoPrism deployed, you can `exec` into the running container and `photoprism import` your photos.
 
 Here's an example YAML file that creates a Kubernetes:
+
 - `Namespace`
 - `Service` exposing PhotoPrism on port 80
 - `StatefulSet` with persistent NFS volumes


### PR DESCRIPTION
I'm not really familiar with MkDocs format specs, but this change solves the issue. The screenshot below is on the [Tests](https://docs.photoprism.org/developer-guide/tests/) page, but the [Kubernetes](https://docs.photoprism.org/getting-started/kubernetes/) has the same problem. I've tried to search over the codebase and only find those two broken pages.

**Before**:

![image](https://user-images.githubusercontent.com/23237214/97656107-3cf5eb00-1a99-11eb-8c70-8c52e738a5fd.png)

**After**:

![image](https://user-images.githubusercontent.com/23237214/97656150-5c8d1380-1a99-11eb-96dc-69cf9a371b09.png)