### PR TITLE
docker-compose: add example with full path

### DIFF
--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -35,7 +35,14 @@ Multiple folders can be indexed by mounting them as sub-folders of `/photoprism/
 volumes:
   - "~/Family:/photoprism/originals/Family"
   - "~/Friends:/photoprism/originals/Friends"
-``` 
+```
+
+Folders outside of the home directory work too:
+
+```
+volumes:
+  - "/media/photos:/photoprism/originals/photos"
+```
 
 The *import* folder points to `~/Import` by default, so that you can easily access it.
 If you don't need this feature, e.g. because you manage all files manually or 


### PR DESCRIPTION
Add one example so that people see different ways to mount directories.