### PR TITLE
Describe how to build frontend in watch mode

### DIFF
--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -30,17 +30,26 @@ docker-compose up
 docker-compose exec photoprism bash
 ```
 
-Now - inside this terminal - you can run tests and commands:
+Now - inside this terminal - you can run tests and commands. To run the Go webserver, run:
 
 ```
-make all
-make test
+make build-go
 ./photoprism start
 ```
 
 You can see a list of all `make` targets in our [Makefile](https://github.com/photoprism/photoprism/blob/develop/Makefile). For example, `make install` will build a `photoprism` production binary without debug information and install it in the user's directory including all assets.
 
-`./photoprism start` starts the built-in Web server. It will listen on [localhost:2342](http://localhost:2342/) by default, see [docker-compose.yml](https://github.com/photoprism/photoprism/blob/develop/docker-compose.yml).
+**Step 4:** Build the frontend in watch mode:
+
+The Go webserver will serve static assets in addition to providing the backend API. The static assets can automatically built whenever you change a file. In a new terminal window, outside the Docker container, run:
+
+```
+cd frontend
+npm install
+npm run watch
+```
+
+PhotoPrism will now be available at [localhost:2342](http://localhost:2342/). This is set in the [docker-compose.yml](https://github.com/photoprism/photoprism/blob/develop/docker-compose.yml).
 
 Questions?
 

--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -38,7 +38,7 @@ make build-go
 ./photoprism start
 ```
 
-You can see a list of all `make` targets in our [Makefile](https://github.com/photoprism/photoprism/blob/develop/Makefile). For example, `make test` will run teht tests and `make install` will build a `photoprism` production binary without debug information and install it in the user's directory including all assets.
+You can see a list of all `make` targets in our [Makefile](https://github.com/photoprism/photoprism/blob/develop/Makefile). For example, `make test` will run the tests and `make install` will build a `photoprism` production binary without debug information and install it in the user's directory including all assets.
 
 **Step 4:** Build the frontend in watch mode:
 

--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -30,23 +30,23 @@ docker-compose up
 docker-compose exec photoprism bash
 ```
 
-Now - inside this terminal - you can run tests and commands. To run the Go webserver, run:
+Now you can run commands inside this terminal. To run the Go webserver, run:
 
 ```
+make dep-tensorflow dep-go generate
 make build-go
 ./photoprism start
 ```
 
-You can see a list of all `make` targets in our [Makefile](https://github.com/photoprism/photoprism/blob/develop/Makefile). For example, `make install` will build a `photoprism` production binary without debug information and install it in the user's directory including all assets.
+You can see a list of all `make` targets in our [Makefile](https://github.com/photoprism/photoprism/blob/develop/Makefile). For example, `make test` will run teht tests and `make install` will build a `photoprism` production binary without debug information and install it in the user's directory including all assets.
 
 **Step 4:** Build the frontend in watch mode:
 
 The Go webserver will serve static assets in addition to providing the backend API. The static assets can automatically built whenever you change a file. In a new terminal window, outside the Docker container, run:
 
 ```
-cd frontend
-npm install
-npm run watch
+make dep-js
+make watch-js
 ```
 
 PhotoPrism will now be available at [localhost:2342](http://localhost:2342/). This is set in the [docker-compose.yml](https://github.com/photoprism/photoprism/blob/develop/docker-compose.yml).


### PR DESCRIPTION
It would be useful to have the contributor's guide list the normal set of steps you'd run during development. `make all` builds more than would typically be desired. Normally a developer will build the frontend and backend separately