### PR TITLE
Add backup docs

### DIFF
--- a/docs/getting-started/advanced/backup.md
+++ b/docs/getting-started/advanced/backup.md
@@ -1,0 +1,14 @@
+# Backup
+
+There are two primary things you need to backup:
+
+1. Your pictures
+2. Photoprism's database
+
+All your pictures reside in your "Originals" directory.
+Including that one in your backup is essential to avoid data loss.
+
+In regards to photoprism's database, the easiest way is to use the built-in `backup` command.
+See `photoprism backup --help` for detailed information on how to use it.
+
+Please also see this [discussion](https://github.com/photoprism/photoprism/discussions/772) for more information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Databases: getting-started/advanced/databases.md
       - Caching: getting-started/advanced/caching.md
       - NGINX: getting-started/advanced/nginx-proxy-setup.md
+      - Backup: getting-started/advanced/backup.md
     - FAQ: getting-started/faq.md
   - User Guide:
     - Introduction: user-guide/index.md


### PR DESCRIPTION
As promised long ago, here is a short entry in the documentation on backing up pictures using photoprism.

I've also linked to the (ongoing) discussion for the more curious users.