### PR TITLE
Update import-vs-index.md

### DIFF
--- a/docs/user-guide/library/import-vs-index.md
+++ b/docs/user-guide/library/import-vs-index.md
@@ -36,6 +36,7 @@ After indexing your originals folder has not been touched:
 
 * You keep your existing folder structure
 * You can display your existing folder structure in PhotoPrism
+* You can move photos between the various folders within your Originals folder.  PhotoPrism will recognize this move and update appropriately during the next index.
 
 ### Import ###
 


### PR DESCRIPTION
I've added to the docs that moving photos within the originals folders is supported.  My goal is to communicate that PhotoPrism will recognize such a change on the disk as a **move** and not as a deletion of the original and addition of the new photo.
Recognizing it as a **move** means that any tags or other metadata added in PhotoPrism will remain in tact.