### PR TITLE
search: show another way to do an “and” query

### DIFF
--- a/docs/user-guide/organize/search.md
+++ b/docs/user-guide/organize/search.md
@@ -49,6 +49,12 @@ Additionally some filters can be used with &:
 keywords:buffalo&water
 ```
 
+Or:
+
+```bigquery
+keywords:"buffalo & water"
+```
+
 This query will show all photos that have the keywords water **and** buffalo.
 
 & is supported by the following filters:


### PR DESCRIPTION
Thanks for the commit 9690c28a8849ac252a290f99e9eacfad2ec5daa4 that added that.

Add another way that works too, and easier to read in my opinion, see https://github.com/photoprism/photoprism/issues/881#issuecomment-908389394