### PR TITLE
Correct search docs regarding album search term

### DIFF
--- a/docs/user-guide/organize/search.md
+++ b/docs/user-guide/organize/search.md
@@ -102,7 +102,7 @@ PhotoPrism allows you to use multiple filters in its search.
 | Filter      | Examples | Notes |
 | ----------- | ----------- | - |
 | after      |    2015-06-30    | |
-| albums | "Holiday 2020" | Album Name |
+| album | "ar66ki01cd9m6pnt" | Album ID |
 | archived     |    yes, no    | |
 | before      |   2016-12-22     | |
 | chroma     |   5     | |


### PR DESCRIPTION
When trying to use the [search docs](https://docs.photoprism.app/user-guide/organize/search/) to search only for photos in a certain album, I found that using the syntax described on the docs (`albums:"<title of album>"`) did not work for me. I had to use `album:"<ID of album>"` (`album` with no S, and ID instead of title of album) to get the expected results.

For example, the following worked (I found the string ID of the album in the URL for that album): 
![album-search](https://user-images.githubusercontent.com/684904/151703991-88e9a34c-8fdc-4661-b3eb-ba887d544d36.png)

However searching by the album name (eg `album:"2022-01-23"` or `albums:"2022-01-23"`) included many pictures not in the album. Searching with `albums:` (with S) and using the ID of the album returned no results (eg `albums:"ar66h2u1kjj3myku"`).

This change updates the docs according to my experience.

However I'm new to photoprism and I suspect that I'm missing something. Please feel free to tell me what I'm doing wrong, and indicate to me how I can clarify the docs so that others don't run into the same thing as me.