### PR TITLE
weblate: add direct link to the Backend

### DIFF
--- a/docs/developer-guide/translations-weblate.md
+++ b/docs/developer-guide/translations-weblate.md
@@ -20,7 +20,7 @@ You can easily register and edit translations without having any programming ski
     2. Select the language you want translate to
 
        ![Screenshot](img/WeblateChooseLanguages.png)
-    3. Open your *Dashboard* and click *Backend*
+    3. Open your *Dashboard* and click *Backend* (or access to the Backend by clicking [here](https://translate.photoprism.app/projects/photoprism/backend/))
 
       ![Screenshot](img/WeblateDashboard.png)
     4. Click on *View contributor agreement*


### PR DESCRIPTION
My dashboard doesn't show the Backend:

> ![image](https://user-images.githubusercontent.com/2071331/161585313-62483480-6ecd-4fe8-a2c2-2769928ca140.png)

Possible reason: I chose the French language and it's already 100% translated.

So I added a link in the doc to open the page directly.