### PR TITLE
Add an example for changing the config values with docker-compose

### DIFF
--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -270,6 +270,7 @@ PhotoPrism's command-line interface is well suited for job automation using a
 | *Download Updates*                                    | `docker-compose pull`                                               |
 | *Uninstall*                                           | `docker-compose rm -s -v`                                           |
 | [*View Logs*](troubleshooting/docker.md#viewing-logs) | `docker-compose logs --tail=100 -f`                                 |
+| *Enable Debug Logs*                                   | `docker-compose exec photoprism photoprism --debug show config`     |
 | *Display Config Values*                               | `docker-compose exec photoprism photoprism config`                  |
 | *Repeat Failed Migrations*                            | `docker-compose exec photoprism photoprism migrations run --failed` |
 | *Reset Database*                                      | `docker-compose exec photoprism photoprism reset`                   |                   


### PR DESCRIPTION
Was having a hard time figuring out how to change the config values with, say, `--originals-limit`, so I figured out how to do it, and added an example in the Docker Compose page. The example shows you how to use `--debug` to enable debugging logs, however is applicable to any config option change.

Note that this example is for photoprism:preview, not photoprism:latest.