### PR TITLE
Increase max body size

### DIFF
--- a/docs/getting-started/proxies/nginx.md
+++ b/docs/getting-started/proxies/nginx.md
@@ -33,6 +33,8 @@ This [tutorial](https://www.serverlab.ca/tutorials/linux/web-servers-linux/how-t
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection "upgrade";
+          
+          client_max_body_size 500M;
         }
       }
     }


### PR DESCRIPTION
Increase the max body size to 500 MB of an http request, since you may want to upload huge stuff via the upload GUI / webDAV