### PR TITLE
Troubleshooting: Add note regarding missing files in zip downloads

### DIFF
--- a/docs/getting-started/troubleshooting/index.md
+++ b/docs/getting-started/troubleshooting/index.md
@@ -159,6 +159,10 @@ In case the application logs don't contain anything helpful:
 
 *Depending on the cause of the problem, you may need to perform a full rescan once the issue is resolved.*
 
+#### ZIP Files ####
+
+If you're trying to download multiple photos and notice that some are missing from the resulting zip archive, or you get an error message saying "No files available for downloading", your index might be incomplete or outdated (e.g. after an update of PhotoPrism). A full rescan of your library should fix this.
+
 ### Wrong Search Results ###
 
 If search results are incorrect, for example, in the wrong order or not filtered properly:


### PR DESCRIPTION
Just had the same problem as photoprism/photoprism#2412

Since no errors show up in the logs etc. it took me way too long to debug this. (And I only even noticed by accident, since there were just a few photos missing on a download of ~400)

Try to help anyone who might stumble upon this in the future by adding it to the troubleshooting checklist. Hopefully people will actually try that checklist, or at least Google will index this at some point and direct people there.