### PR TITLE
Remove backticks

### DIFF
--- a/docs/user-guide/search/filters.md
+++ b/docs/user-guide/search/filters.md
@@ -25,7 +25,9 @@ If you set multiple filters, only pictures that meet all filter criteria will be
 
 In addition, these and many other filters can be entered into the toolbar search box as follows:
 
-    `label:cat color:green type:live`
+```
+label:cat color:green type:live
+```
 
 A complete overview of the [available search filters](#filter-reference) can be found below.
 


### PR DESCRIPTION
This is a minor change to remove the literal backticks (`) that show up in the rendered documentation and make this part consistent with the other code quotes.