### PR TITLE
[DOCS] Fix typo in backups.md docker-compose example

### DIFF
--- a/docs/getting-started/advanced/backups.md
+++ b/docs/getting-started/advanced/backups.md
@@ -11,7 +11,7 @@ photoprism backup -i [filename]
 Or the following for [docker-compose](../docker-compose.md):
 
 ```bash
-docker compose exec -T photoprism photoprism backup -i - > photoprism-db.sql
+docker-compose exec -T photoprism photoprism backup -i - > photoprism-db.sql
 ```
 
 As seen above, you can use `-` as filename to write the backup to stdout.


### PR DESCRIPTION
Example docker-compose command was missing the hyphen ("docker compose"), so command was failing.