### PR TITLE
highlight the read-only mode and storage mounts

### DIFF
--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -147,6 +147,13 @@ volumes:
   - "/example/friends:/photoprism/originals/friends"
   - "/mnt/photos:/photoprism/originals/media"
 ```
+You can [mount folders with the `:ro` flag](https://docs.docker.com/compose/compose-file/compose-file-v3/#short-syntax-3) to make Docker block write operations. Even with *read-only mode* disabled, these volumes will be protected from accidental file edit/delete you may do in PhotoPrism:
+
+```yaml
+volumes:
+  - "/home/username/Pictures:/photoprism/originals"
+  - "/example/friends:/photoprism/originals/friends:ro" # Read-only folder
+```
 
 On Windows, prefix the host path with the drive letter and use `/` instead of `\` as separator:
 
@@ -158,17 +165,21 @@ volumes:
 !!! tldr ""
     If *read-only mode* is enabled, all features that require write permission to the *originals* folder 
     are disabled, e.g. [WebDAV](../user-guide/sync/webdav.md), uploading and deleting files. Set `PHOTOPRISM_READONLY` to `"true"`
-    in `docker-compose.yml` for this. You can [mount a folder with the `:ro` flag](https://docs.docker.com/compose/compose-file/compose-file-v3/#short-syntax-3) to make Docker block 
-    write operations as well.
+    in `docker-compose.yml` for this. 
 
 ##### /photoprism/storage #####
 
-SQLite, config, cache, thumbnail and sidecar files are saved in the *storage* folder:
+The *storage* folder is used by PhotoPrism to save SQLite, config, cache, thumbnail and sidecar files:
 
-- a *storage* folder mount must always be configured in your `docker-compose.yml` file so that you do not lose these files after a restart or upgrade
+- a *storage* folder mount (with write access) must always be configured in your `docker-compose.yml` file so that you do not lose these files after a restart or upgrade
 - never configure the *storage* folder to be inside the *originals* folder unless the name starts with a `.` to indicate that it is hidden
 - we recommend placing the *storage* folder on a [local SSD drive](troubleshooting/performance.md#storage) for best performance
 - mounting [symbolic links](https://en.wikipedia.org/wiki/Symbolic_link) or using them inside the *storage* folder is currently not supported
+
+```yaml
+volumes:
+  - "./storage:/photoprism/storage"
+```
 
 !!! tldr ""
     Should you later want to move your instance to another host, the easiest and most time-saving way is to copy the entire *storage* folder along with your originals and database.


### PR DESCRIPTION
highlighted and show example of mounting a volume with read-only flag.  added example for storage mount with write access since it's required (or highly recommended).