### PR TITLE
Clarify PHOTOPRISM_TRUSTED_PROXY

### DIFF
--- a/docs/getting-started/config-options.md
+++ b/docs/getting-started/config-options.md
@@ -118,7 +118,7 @@
 |---------------------------------|------------------------|-------------------|-------------------------------------------------------------------|
 | PHOTOPRISM_HTTPS_PROXY          | --https-proxy          |                   | proxy server `URL` to be used for outgoing connections *optional* |
 | PHOTOPRISM_HTTPS_PROXY_INSECURE | --https-proxy-insecure |                   | ignore invalid HTTPS certificates when using a proxy              |
-| PHOTOPRISM_TRUSTED_PROXY        | --trusted-proxy        | 172.16.0.0/12     | `CIDR` range from which reverse proxy headers can be trusted      |
+| PHOTOPRISM_TRUSTED_PROXY        | --trusted-proxy        | 172.16.0.0/12     | `CIDR` ranges or IPv4/v6 addresses from which reverse proxy headers can be trusted, separated by commas      |
 | PHOTOPRISM_PROXY_PROTO_HEADER   | --proxy-proto-header   | X-Forwarded-Proto | proxy protocol header `NAME`                                      |
 | PHOTOPRISM_PROXY_PROTO_HTTPS    | --proxy-proto-https    | https             | forwarded HTTPS protocol `NAME`                                   |
 


### PR DESCRIPTION
Clarify that PHOTOPRISM_TRUSTED_PROXY is passed to Gin per https://github.com/gin-gonic/gin/blob/457fabd7e14f36ca1b5f302f7247efeb4690e49c/docs/doc.md#dont-trust-all-proxies

See https://github.com/photoprism/photoprism/discussions/3382