### PR TITLE
Fix cert-manager annotation in example ingress

### DIFF
--- a/docs/getting-started/advanced/kubernetes.md
+++ b/docs/getting-started/advanced/kubernetes.md
@@ -133,7 +133,7 @@ metadata:
     # Default is very low so most photo uploads will fail
     nginx.ingress.kubernetes.io/proxy-body-size: "512M"
     # If using cert-manager:
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/tls-acme: "true"
   name: photoprism
   namespace: photoprism


### PR DESCRIPTION
Annotation was outdated. See the official docs for the correct annotation name.

https://cert-manager.io/docs/usage/ingress/