### PR TITLE
Kubernetes: Update instructions to properly mount the storage path

### DIFF
--- a/docs/getting-started/advanced/kubernetes.md
+++ b/docs/getting-started/advanced/kubernetes.md
@@ -59,6 +59,10 @@ spec:
         env:
         - name: PHOTOPRISM_DEBUG
           value: "true"
+        - name: PHOTOPRISM_IMPORT_PATH
+          value: /import
+        - name: PHOTOPRISM_ORIGINALS_PATH
+          value: /originals
         - name: PHOTOPRISM_DATABASE_DRIVER
           value: mysql
         - name: PHOTOPRISM_HTTP_HOST
@@ -74,21 +78,29 @@ spec:
         - containerPort: 2342
           name: http
         volumeMounts:
-        - mountPath: /photoprism
-          name: photoprism
+        - mountPath: /originals
+          name: originals
+        - mountPath: /import
+          name: import
+        - mountPath: /photoprism/storage
+          name: photoprism-storage
         readinessProbe:
           httpGet:
             path: /api/v1/status
             port: http
       volumes:
-      - name: photoprism
+      - name: originals
         nfs:
-          path: /share
+          path: /originals
           readOnly: true
           server: my.nas.host
-      - name: photoprism
+      - name: import
         nfs:
-          path: /photoprism
+          path: /import
+          server: my.nas.host
+      - name: photoprism-storage
+        nfs:
+          path: /photoprism-storage
           server: my.nas.host
 ---
 apiVersion: v1

--- a/docs/getting-started/advanced/kubernetes.md
+++ b/docs/getting-started/advanced/kubernetes.md
@@ -59,14 +59,6 @@ spec:
         env:
         - name: PHOTOPRISM_DEBUG
           value: "true"
-        - name: PHOTOPRISM_CACHE_PATH
-          value: /assets/cache
-        - name: PHOTOPRISM_IMPORT_PATH
-          value: /assets/photos/import
-        - name: PHOTOPRISM_EXPORT_PATH
-          value: /assets/photos/export
-        - name: PHOTOPRISM_ORIGINALS_PATH
-          value: /assets/photos/originals
         - name: PHOTOPRISM_DATABASE_DRIVER
           value: mysql
         - name: PHOTOPRISM_HTTP_HOST
@@ -82,24 +74,14 @@ spec:
         - containerPort: 2342
           name: http
         volumeMounts:
-        - mountPath: /assets/photos/originals
-          name: originals
-          subPath: media/photos
-        - mountPath: /assets/cache
+        - mountPath: /photoprism
           name: photoprism
-          subPath: cache
-        - mountPath: /assets/photos/import
-          name: photoprism
-          subPath: import
-        - mountPath: /assets/photos/export
-          name: photoprism
-          subPath: export
         readinessProbe:
           httpGet:
             path: /api/v1/status
             port: http
       volumes:
-      - name: originals
+      - name: photoprism
         nfs:
           path: /share
           readOnly: true


### PR DESCRIPTION
The kubernetes instructions had a few issues. Namely,

* `PHOTOPRISM_EXPORT_PATH` was being set, but this doesn't seem to have any effect (or at least this env var isn't documented anywhere else)
* `PHOTOPRISM_STORAGE_PATH` was not explicitly set, so it would default to `/photoprism/storage`, which would be in ephemeral storage (since that directory was not declared as a volume)
* `PHOTOPRISM_BACKUP_PATH` was similarly not set, so the directory would have been ephemeral.

In my experience, these problems (especially the unset `PHOTOPRISM_STORAGE_PATH` var) caused issues since it meant that photoprism was unable to store API keys on boot, preventing the activation of a membership.