### PR TITLE
Update config-options.md

### DIFF
--- a/docs/getting-started/config-options.md
+++ b/docs/getting-started/config-options.md
@@ -175,7 +175,7 @@
 | PHOTOPRISM_FFMPEG_SIZE           | --ffmpeg-size           |                           3840 | maximum video size in `PIXELS` (720-7680)                             |
 | PHOTOPRISM_FFMPEG_BITRATE        | --ffmpeg-bitrate        |                             50 | maximum video `BITRATE` in Mbit/s                                     |
 | PHOTOPRISM_FFMPEG_MAP_VIDEO      | --ffmpeg-map-video      | 0:&zwnj;v:0                          | video `STREAMS` that should be transcoded                             |
-| PHOTOPRISM_FFMPEG_MAP_AUDIO      | --ffmpeg-map-audio      | 0:&zwnj;a:0                          | audio `STREAMS` that should be transcoded                             |
+| PHOTOPRISM_FFMPEG_MAP_AUDIO      | --ffmpeg-map-audio      | 0:&zwnj;a:0?                         | audio `STREAMS` that should be transcoded                             |
 | PHOTOPRISM_EXIFTOOL_BIN          | --exiftool-bin          | exiftool                       | ExifTool `COMMAND` for extracting metadata                            |
 | PHOTOPRISM_DARKTABLE_BIN         | --darktable-bin         | darktable-cli                  | Darktable CLI `COMMAND` for RAW to JPEG conversion                    |
 | PHOTOPRISM_DARKTABLE_BLACKLIST   | --darktable-blacklist   |                                | do not use Darktable to convert files with these `EXTENSIONS`         |

--- a/docs/getting-started/config-options.md
+++ b/docs/getting-started/config-options.md
@@ -174,8 +174,8 @@
 | PHOTOPRISM_FFMPEG_ENCODER        | --ffmpeg-encoder        | libx264                        | FFmpeg AVC encoder `NAME`                                             |
 | PHOTOPRISM_FFMPEG_SIZE           | --ffmpeg-size           |                           3840 | maximum video size in `PIXELS` (720-7680)                             |
 | PHOTOPRISM_FFMPEG_BITRATE        | --ffmpeg-bitrate        |                             50 | maximum video `BITRATE` in Mbit/s                                     |
-| PHOTOPRISM_FFMPEG_MAP_VIDEO      | --ffmpeg-map-video      | 0:v:0                          | video `STREAMS` that should be transcoded                             |
-| PHOTOPRISM_FFMPEG_MAP_AUDIO      | --ffmpeg-map-audio      | 0:a:0?                         | audio `STREAMS` that should be transcoded                             |
+| PHOTOPRISM_FFMPEG_MAP_VIDEO      | --ffmpeg-map-video      | 0:&zwnj;v:0                          | video `STREAMS` that should be transcoded                             |
+| PHOTOPRISM_FFMPEG_MAP_AUDIO      | --ffmpeg-map-audio      | 0:&zwnj;a:0                          | audio `STREAMS` that should be transcoded                             |
 | PHOTOPRISM_EXIFTOOL_BIN          | --exiftool-bin          | exiftool                       | ExifTool `COMMAND` for extracting metadata                            |
 | PHOTOPRISM_DARKTABLE_BIN         | --darktable-bin         | darktable-cli                  | Darktable CLI `COMMAND` for RAW to JPEG conversion                    |
 | PHOTOPRISM_DARKTABLE_BLACKLIST   | --darktable-blacklist   |                                | do not use Darktable to convert files with these `EXTENSIONS`         |


### PR DESCRIPTION
Add a zero-width non-joiner character to prevent parsing `:a:` and `:v:` as emojis.