### PR TITLE
Getting Started: Improve MariaDB troubleshooting guide  - passwords

### DIFF
--- a/docs/getting-started/troubleshooting/mariadb.md
+++ b/docs/getting-started/troubleshooting/mariadb.md
@@ -191,7 +191,7 @@ to all users after a restart:
 ```yaml
 services:
   mariadb:
-    command: mysqld --skip-grant-tables
+    command: --skip-grant-tables
 ```
 
 Restart the `mariadb` service for changes to take effect:
@@ -213,8 +213,6 @@ Enter the following commands to change the password for "root":
 FLUSH PRIVILEGES;
 ALTER USER 'root'@'%' IDENTIFIED BY 'new_password';
 ALTER USER 'root'@'localhost' IDENTIFIED BY 'new_password';
-UPDATE mysql.user SET authentication_string = '' WHERE user = 'root';
-UPDATE mysql.user SET plugin = '' WHERE user = 'root';
 exit
 ```
 


### PR DESCRIPTION
mysqld isn't needed as part of command (and won't work from 11.0+).

Updating mysql.user cannot be done in 10.4+, was never a real mechanism, and from 10.4+ plugin authentication and passwords where accepted.

Setting password with ALTER USER (or SET PASSWORD) is all that is required.