### PR TITLE
Clarify MPEG4-AVC encoding docs

### DIFF
--- a/docs/getting-started/advanced/transcoding.md
+++ b/docs/getting-started/advanced/transcoding.md
@@ -35,6 +35,9 @@ The [`PHOTOPRISM_FFMPEG_SIZE`](../config-options.md#file-conversion) config opti
 
 !!! tldr ""
     When transcoding videos, the original aspect ratio is maintained and smaller videos will not be upscaled.
+    
+!!! tldr ""
+    Note that MPEG-4 AVC videos are not re-encoded if they exceed the configured resolution limit.
 
 ### Bitrate Limit ###
 


### PR DESCRIPTION
Clarify that MPEG4-AVC is not reencoded when resolution exceeds limit
