### PR TITLE
Getting Started: Add responding timeout for Traefik

### DIFF
--- a/docs/getting-started/proxies/traefik.md
+++ b/docs/getting-started/proxies/traefik.md
@@ -57,7 +57,9 @@ To run PhotoPrism behind Traefik, create a `traefik.yaml` configuration and then
         address: ":443"
         transport:
           respondingTimeouts:
-            readTimeout: "0s"
+            readTimeout: "1h"
+            writeTimeout: "0s"
+            idleTimeout: "300s"
 
     providers:
       docker:

--- a/docs/getting-started/proxies/traefik.md
+++ b/docs/getting-started/proxies/traefik.md
@@ -55,6 +55,9 @@ To run PhotoPrism behind Traefik, create a `traefik.yaml` configuration and then
               scheme: https
       websecure:
         address: ":443"
+        transport:
+          respondingTimeouts:
+            readTimeout: "0s"
 
     providers:
       docker:


### PR DESCRIPTION
A [while ago](https://doc.traefik.io/traefik/migration/v2/#v2112), Traefik changed the default value of responding timeouts from none to 60 seconds. This breaks larger uploads, like videos.

To fix this, we have to specify the read timeout specifically in the HTTPS entrypoint config of Traefik.