### PR TITLE
fix: path to vision.yml

### DIFF
--- a/docs/developer-guide/vision/service/index.md
+++ b/docs/developer-guide/vision/service/index.md
@@ -99,6 +99,8 @@ Now, create a new `config/vision.yml` file or edit the existing file in [the *st
 !!! note ""
     The config file must be named `vision.yml`, not `vision.yaml`, as otherwise it won't be found and will have no effect.
 
+!!! tip "Old installations"
+    See the note in [Configuration](../../../user-guide/ai/index.md#visionyml-reference) if your file is not read.
 
 ## Step 3: Restart PhotoPrism
 

--- a/docs/developer-guide/vision/service/setup.md
+++ b/docs/developer-guide/vision/service/setup.md
@@ -67,6 +67,9 @@ The interaction between PhotoPrism and the Vision service is controlled by a `vi
 !!! warning ""
     The configuration file **must** be named `vision.yml` with the `.yml` extension, **not** `.yaml`. Files with the `.yaml` extension will be ignored by PhotoPrism and could cause the Vision service to appear non-functional.
 
+!!! tip "Old installations"
+    See the note in [Configuration](../../../user-guide/ai/index.md#visionyml-reference) if your file is not read.
+
 The file consists of a list of `Models` and a `Thresholds` section.
 
 !!! example "`storage/config/vision.yml`"

--- a/docs/developer-guide/vision/tensorflow/custom-models.md
+++ b/docs/developer-guide/vision/tensorflow/custom-models.md
@@ -51,6 +51,9 @@ Now, create a new `config/vision.yml` file or edit the existing file in [the *st
 !!! note ""
     The config file must be named `vision.yml`, not `vision.yaml`, as otherwise it won't be found and will have no effect.
 
+!!! tip "Old installations"
+    See the note in [Configuration](../../../user-guide/ai/index.md#visionyml-reference) if your file is not read. 
+
 ## Step 4: Restart PhotoPrism
 
 Run the following commands to restart `photoprism` and apply the new settings:

--- a/docs/user-guide/ai/index.md
+++ b/docs/user-guide/ai/index.md
@@ -27,6 +27,13 @@ PhotoPrism currently supports the following runtimes and services:
 
 Custom AI engines, models, and run modes can be specified in a `vision.yml` file located in the `storage/config` directory. The file defines a list of models and thresholds to be used, e.g.:
 
+!!! warning "Old installations"
+    On old installations of PhotoPrism, the path may be `storage/settings`.
+
+    Run `docker compose exec photoprism photoprism show config | grep config-path` to check it.
+
+    If you see that the value of `config-path` is `/photoprism/storage/settings`, then set `PHOTOPRISM_VISION_YAML: "/photoprism/storage/config/vision.yml"` in your environment to use the path `storage/config` with `vision.yml`.
+
 ```yaml
 Models:
 - Type: caption

--- a/docs/user-guide/ai/ollama-models.md
+++ b/docs/user-guide/ai/ollama-models.md
@@ -58,6 +58,9 @@ For other languages, keep the base instructions in English and add the desired l
 
 The following drop-in examples can be specified in your `vision.yml` file, which is located in the `storage/config` directory. [Learn more ›](index.md#visionyml-reference).
 
+!!! tip "Old installations"
+    See the note in [Configuration](./index.md#visionyml-reference) if your file is not read.
+
 ### Gemma 3: Labels
 
 ```yaml

--- a/docs/user-guide/ai/using-ollama.md
+++ b/docs/user-guide/ai/using-ollama.md
@@ -85,6 +85,9 @@ docker compose exec ollama ollama pull gemma3:latest
 
 Now, create a new `config/vision.yml` file or edit the existing file in [the *storage* folder](../../getting-started/docker-compose.md#photoprismstorage) of your PhotoPrism instance, following the example below. Its absolute path from inside the container is `/photoprism/storage/config/vision.yml`:
 
+!!! tip "Old installations"
+    See the note in [Configuration](./index.md#visionyml-reference) if your file is not read.
+
 !!! example "vision.yml"
     ```yaml
     Models:
@@ -177,4 +180,3 @@ docker compose up -d ollama
 This should clear the VRAM and restore normal GPU-accelerated processing performance.
 
 [^1]: Unrelated configuration details have been omitted for brevity.
-


### PR DESCRIPTION
The file `storage/config/vision.yml` is ignored, while `storage/settings/vision.yml` is read.

See:

- https://github.com/photoprism/photoprism/discussions/5368#discussioncomment-15181640

Another way would be to fix this in the code of PhotoPrism, but I didn't find the source of this path.

The function `VisionYaml` call `ConfigPath` so it should read the file `storage/config/`:

- https://github.com/photoprism/photoprism/blob/cdf00beda4b774ff7a0d57321a9dff61b89c16b5/internal/config/config_vision.go#L24

But it didn’t work for one user and me.