### PR TITLE
Getting Started: Update FFmpeg transcoding documentation

### DIFF
--- a/docs/getting-started/advanced/transcoding.md
+++ b/docs/getting-started/advanced/transcoding.md
@@ -54,7 +54,7 @@ Note that MPEG-4 AVC videos are not re-encoded if they exceed the [configured bi
 
 Unless you have a lot of high-resolution videos in your library, we recommend keeping the default settings to use the standard software codec for video transcoding. It has a high quality and does not require any special permissions or additional drivers.
 
-Since [FFmpeg 7](https://ffmpeg.org/index.html#pr7.0) has significant [performance optimizations](https://www.debugpoint.com/ffmpeg-7-0-features/) compared to version 6.1.1 that ships with [Ubuntu 24.04](https://packages.ubuntu.com/noble/ffmpeg), users of our [Docker image](https://docs.photoprism.app/release-notes/#may-31-2024) can choose to install the [latest stable FFmpeg build](https://github.com/BtbN/FFmpeg-Builds/releases) from [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) by adding `PHOTOPRISM_INIT: "ffmpeg"` to the environment section of their `compose.yaml` or `docker-compose.yml` file:
+Our Docker images ship with FFmpeg pre-installed, but you can optionally replace it with the [latest stable FFmpeg build](https://github.com/BtbN/FFmpeg-Builds/releases) from [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) by adding `PHOTOPRISM_INIT: "ffmpeg"` to the environment section of your `compose.yaml` or `docker-compose.yml` file:
 
 ```yaml
 services:


### PR DESCRIPTION
The main change is to make it clear that FFmpeg is already pre-installed in the Docker images and to provide guidance for optionally replacing it with a newer build.