### PR TITLE
Docs: Use 'mariadb' client in MariaDB troubleshooting examples

### DIFF
--- a/docs/getting-started/troubleshooting/mariadb.md
+++ b/docs/getting-started/troubleshooting/mariadb.md
@@ -102,7 +102,7 @@ Existing databases may still use a different character set or collation, especia
 
 ```bash
 echo "SHOW VARIABLES WHERE Variable_name LIKE 'character\_set\_%' OR Variable_name LIKE 'collation%';" | \
-docker compose exec -T mariadb mysql -uroot -pinsecure photoprism
+docker compose exec -T mariadb mariadb -uroot -pinsecure photoprism
 ```
 
 Before [submitting a support request](https://www.photoprism.app/kb/getting-support), confirm that the problem also occurs with a **newly created** database based on our [example configuration](https://dl.photoprism.app/docker/compose.yaml):
@@ -307,7 +307,7 @@ docker compose up -d mariadb
 Now open a database console:
 
 ```bash
-docker compose exec mariadb mysql -uroot
+docker compose exec mariadb mariadb -uroot
 ```
 
 Enter the following commands to change the password for "root":


### PR DESCRIPTION
## Summary

- The MariaDB troubleshooting page had two `docker compose exec ... mariadb mysql ...` examples that fail on `mariadb:11+` images, since the official image dropped the legacy `mysql` symlink (upstream [mariadb-docker#512](https://github.com/MariaDB/mariadb-docker/issues/512)).
- Switched both examples to invoke `mariadb` directly. Same binary, same flags — just the canonical name.

Fixes #5548.

## Test plan

- [ ] Run the Unicode-support `SHOW VARIABLES` snippet against a `mariadb:11.8` container and confirm it returns the character-set/collation rows.
- [ ] Run the password-reset console snippet (`docker compose exec mariadb mariadb -uroot`) against a `mariadb:11` container started with `--skip-grant-tables` and confirm the prompt opens.