### PR TITLE
Update API endpoint reference from 'Url' to 'Uri'

### DIFF
--- a/docs/user-guide/ai/using-openai.md
+++ b/docs/user-guide/ai/using-openai.md
@@ -41,7 +41,7 @@ Recommendations:
 - PhotoPrism evaluates models from the bottom of the list up, so putting the OpenAI entries after the others ensures OpenAI is chosen first, leaving other models as backups.
 
 !!! tldr ""
-    By default, PhotoPrism uses the OpenAI Responses API endpoint at `https://api.openai.com/v1/responses` with a single 720 px thumbnail (`detail: low`). It can be changed by setting a custom `Service.Url`.
+    By default, PhotoPrism uses the OpenAI Responses API endpoint at `https://api.openai.com/v1/responses` with a single 720 px thumbnail (`detail: low`). It can be changed by setting a custom `Service.Uri`.
 
 ## Usage Tips
 


### PR DESCRIPTION
The guide says value is named uri and not url.
https://docs.photoprism.app/user-guide/ai/