### PR TITLE
Docs: Explain GPS loss on mobile web upload

### DIFF
--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -124,6 +124,12 @@
 
 ## Maps & Places
 
+??? question "Why is the location missing after I upload photos from my phone?"
+
+    Recent Android versions remove the embedded GPS coordinates from photos when they are read by an app that does not hold the system *media location* permission ([`ACCESS_MEDIA_LOCATION`](https://developer.android.com/training/data-storage/shared/media#location-info-photos)). Because web browsers cannot request this permission, pictures uploaded through the web UI on a phone may arrive without location data. iOS can behave similarly depending on the browser and its privacy settings.
+
+    Note that this happens on the device, *before* the files reach PhotoPrism, so the coordinates cannot be recovered during indexing. To preserve the location, upload the originals from a desktop browser or use a sync app like [PhotoSync](sync/mobile-devices.md#using-photosync), which holds the required permission and transfers files unmodified via WebDAV. You can check whether a file still contains GPS data with [ExifTool](https://exiftool.org/).
+
 ??? question "Why are some pictures positioned at unvisited locations on the map?"
 
     PhotoPrism can estimate the location of pictures taken without GPS information by extrapolating it from the location of other pictures taken on the same day. These estimates can be [disabled in the settings](./settings/library.md) if you don't want them.

--- a/docs/user-guide/library/upload.md
+++ b/docs/user-guide/library/upload.md
@@ -49,3 +49,13 @@ The Upload dialog supports drag-and-drop: drop one or many files (or whole folde
     - In the iOS Photos picker, tap the three-dot menu (…) → *Options* → set **Format** to **Current** instead of **Automatic** so your files are uploaded in the original format.
     - Alternatively, use dedicated sync apps like [PhotoSync](../sync/mobile-devices.md#using-photosync), which can upload files in their original format via WebDAV.
 
+!!! info "Why GPS Location May Be Missing After Uploading from a Phone"
+    Recent Android versions remove the embedded GPS coordinates from photos when they are read by an app that does not hold the system *media location* permission ([`ACCESS_MEDIA_LOCATION`](https://developer.android.com/training/data-storage/shared/media#location-info-photos)). Because web browsers cannot request this permission, pictures uploaded through the web UI on a phone may arrive **without location data**. iOS can behave similarly depending on the browser and its privacy settings.
+
+    This happens on the device, **before** the files reach PhotoPrism, so the coordinates cannot be recovered during indexing. To preserve the embedded location:
+
+    - Upload the original files from a **desktop browser**, or
+    - Use a dedicated sync app such as [PhotoSync](../sync/mobile-devices.md#using-photosync), which holds the required permission and transfers files unmodified via WebDAV.
+
+    You can check whether a file still contains GPS data with [ExifTool](https://exiftool.org/) (for example, `exiftool -a -G1 photo.jpg`).
+


### PR DESCRIPTION
## Summary

Documents why photos uploaded through the web UI from a phone may arrive without GPS/location data: recent Android versions strip the embedded coordinates when an app reads the file without the `ACCESS_MEDIA_LOCATION` permission, and browsers cannot request it. The loss happens on the device, before the file reaches PhotoPrism.

Prompted by photoprism/photoprism#5687, which was closed as not a PhotoPrism bug after it could not be reproduced server-side.

Changes:
- `user-guide/library/upload.md` — adds an admonition next to the existing iOS note, with desktop-upload and PhotoSync/WebDAV workarounds.
- `user-guide/faq.md` — adds a *Maps & Places* FAQ entry for the same question.

## Test plan
- `make watch` renders both pages without MkDocs warnings; new links (PhotoSync anchor, ExifTool, Android docs) resolve.